### PR TITLE
Fix assigns in Migration guide

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -895,7 +895,7 @@ fn my_system(
 +  mut atlases: ResMut<Assets<TextureAtlasLayout>>,
   asset_server: Res<AssetServer>
 ) {
-    let texture_handle: asset_server.load("my_texture.png");
+    let texture_handle = asset_server.load("my_texture.png");
 -   let layout = TextureAtlas::from_grid(texture_handle, Vec2::new(25.0, 25.0), 5, 5, None, None);
 +   let layout = TextureAtlasLayout::from_grid(Vec2::new(25.0, 25.0), 5, 5, None, None);
     let layout_handle = atlases.add(layout);
@@ -923,7 +923,7 @@ fn my_system(
 +  mut atlases: ResMut<Assets<TextureAtlasLayout>>,
   asset_server: Res<AssetServer>
 ) {
-    let texture_handle: asset_server.load("my_texture.png");
+    let texture_handle = asset_server.load("my_texture.png");
 -   let layout = TextureAtlas::from_grid(texture_handle, Vec2::new(25.0, 25.0), 5, 5, None, None);
 +   let layout = TextureAtlasLayout::from_grid(Vec2::new(25.0, 25.0), 5, 5, None, None);
     let layout_handle = atlases.add(layout);


### PR DESCRIPTION
replace `:` where `=` should have been used